### PR TITLE
fix: snyk default exclusions for new projects

### DIFF
--- a/app/gh_repo.py
+++ b/app/gh_repo.py
@@ -23,11 +23,15 @@ def get_repo_manifests(snyk_repo_name, origin):
 
     while contents:
         file_content = contents.pop(0)
-        # print(file_content.path)
-        if re.match(common.MANIFEST_REGEX_PATTERN, file_content.path):
-            #print('re matched one: ' + file_content.path)
+        if passes_manifest_filter(file_content.path):
             manifests.append(file_content.path)
     return manifests
+
+def passes_manifest_filter(path):
+    """ check if given path should be imported based
+        on configured search and exclusion filters """
+    return bool(re.match(common.MANIFEST_REGEX_PATTERN, path) and
+            not re.match(common.MANIFEST_EXCLUSION_REGEX_PATTERN, path))
 
 def get_gh_repo_status(snyk_gh_repo, github_token, github_enterprise=False):
     """detect if repo still exists, has been removed, or renamed"""

--- a/app/tests/test_snyk_scm_refresh.py
+++ b/app/tests/test_snyk_scm_refresh.py
@@ -2,7 +2,10 @@
 import pytest
 from snyk.models import Project
 
-from app.gh_repo import get_gh_repo_status
+from app.gh_repo import (
+    get_gh_repo_status,
+    passes_manifest_filter
+)
 from app.utils.snyk_helper import get_snyk_projects_for_repo
 
 class MockResponse:
@@ -147,4 +150,13 @@ def test_get_snyk_project_for_repo():
 
     assert get_snyk_projects_for_repo(snyk_projects, \
         "scotte-snyk/test-project-1") == snyk_projects_filtered
-    
+
+def test_passes_manifest_filter():
+    path_fail_1 = "/__test__/path/project.csproj"
+    path_fail_2 = "/node_modules/some/package.json"
+    path_pass_1 = "package.json"
+    path_pass_2 = "requirements-test.txt"
+    assert passes_manifest_filter(path_fail_1) == False
+    assert passes_manifest_filter(path_pass_1) == True
+    assert passes_manifest_filter(path_fail_2) == False
+    assert passes_manifest_filter(path_pass_2) == True

--- a/common.py
+++ b/common.py
@@ -7,6 +7,7 @@ from app.utils.github_utils import (
 import argparse
 
 MANIFEST_REGEX_PATTERN = '^(?![.]).*(package[.]json$|Gemfile[.]lock$|pom[.]xml$|build[.]gradle$|.*[.]lockfile$|build[.]sbt$|.*req.*[.]txt$|Gopkg[.]lock|go[.]mod|vendor[.]json|packages[.]config|.*[.]csproj|.*[.]fsproj|.*[.]vbproj|project[.]json|project[.]assets[.]json|composer[.]lock|Podfile|Podfile[.]lock|.*[.]yaml|.*[.]yml|Dockerfile)'
+MANIFEST_EXCLUSION_REGEX_PATTERN = '^.*(fixtures|\/tests\/|\/__tests__\/|\/test\/|__test__|[.].*ci\/|\/node_modules\/|\/bower_components\/).*$'
 
 GITHUB_ENABLED = False
 GITHUB_ENTERPRISE_ENABLED = False


### PR DESCRIPTION
do not import files matching the following regex:

```
'^.*(fixtures|\/tests\/|\/__tests__\/|\/test\/|__test__|[.].*ci\/|\/node_modules\/|\/bower_components\/).*$'
```