### PR TITLE
fix: virtual environment compatible shebang

### DIFF
--- a/snyk_scm_refresh.py
+++ b/snyk_scm_refresh.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 """
 Keep Snyk projects in sync with their corresponding SCM repositories
 """


### PR DESCRIPTION
Hi!
This was not working for me in a `venv`, I was getting:
```
./snyk_scm_refresh.py -h
Traceback (most recent call last):
  File "/Users/marc.penya/Software/github.com/snyk-tech-services/snyk-scm-refresh/./snyk_scm_refresh.py", line 8, in <module>
    import common
  File "/Users/marc.penya/Software/github.com/snyk-tech-services/snyk-scm-refresh/common.py", line 6, in <module>
    from snyk import SnykClient
ModuleNotFoundError: No module named 'snyk'
```

I've read here https://stackoverflow.com/questions/6908143/should-i-put-shebang-in-python-scripts-and-what-form-should-it-take#comment8226670_6908143 that the shebang should be modified for the script to work inside a `venv`.
