### PR TITLE
Raise unhandled SnykHTTPErrors in import_manifest

### DIFF
--- a/app/utils/snyk_helper.py
+++ b/app/utils/snyk_helper.py
@@ -195,6 +195,8 @@ def import_manifests(org_id, repo_full_name, integration_id, files=[]) -> Import
             except snyk.errors.SnykHTTPError as err_retry:
                 print(f"Still failed after retry with {str(err_retry.code)}!")
                 raise
+        else:
+            raise
     return ImportStatus(re.search('org/.+/integrations/.+/import/(.+)',
                                   response.headers['Location']).group(1),
                         response.headers['Location'],


### PR DESCRIPTION
Fixes #69

Most `SnykHTTPError` exceptions in the `import_manifests` function are being suppressed and continuing to later code, which causes a crash.