### PR TITLE
fix: prevent skipping of last repository

### DIFF
--- a/app/snyk_repo.py
+++ b/app/snyk_repo.py
@@ -32,6 +32,17 @@ class SnykRepo():
         self.origin = origin
         self.branch = branch
         self.snyk_projects = snyk_projects
+
+    def __repr__(self):
+        return (
+            f"{self.full_name}" + "\n"
+            f"{self.org_id}" + "\n"
+            f"{self.org_name}" + "\n"
+            f"{self.integration_id}" + "\n"
+            f"{self.origin}" + "\n"
+            f"{self.branch}" + "\n"
+            f"{self.snyk_projects}")
+
     def __getitem__(self, item):
         return self.__dict__[item]
 

--- a/app/tests/test_snyk_scm_refresh.py
+++ b/app/tests/test_snyk_scm_refresh.py
@@ -10,7 +10,10 @@ from app.gh_repo import (
     get_gh_repo_status,
     passes_manifest_filter,
 )
-from app.utils.snyk_helper import get_snyk_projects_for_repo
+from app.utils.snyk_helper import (
+    get_snyk_projects_for_repo,
+    get_snyk_repos_from_snyk_projects
+)
 
 class MockResponse:
     """ mock response for github check """
@@ -118,6 +121,65 @@ def test_get_gh_repo_status_unauthorized(mocker):
 
     with pytest.raises(RuntimeError):
         get_gh_repo_status(snyk_repo)
+
+def test_get_snyk_repos_from_snyk_projects():
+    """ test generating unique repos from project list """
+
+    snyk_gh_projects = [
+    {
+        "id": "12345",
+        "name": "scotte-snyk/test-project-1:package.json",
+        "repo_full_name": "scotte-snyk/test-project-1",
+        "repo_owner": "scotte-snyk",
+        "repo_name": "test-project-1",
+        "manifest": "package.json",
+        "org_id": "12345",
+        "org_name": "scotte-snyk",
+        "origin": "github",
+        "type": "npm",
+        "integration_id": "66d7ebef-9b36-464f-889c-b92c9ef5ce12",
+        "branch_from_name": "",
+        "branch": "master"
+    },
+    {
+        "id": "12345",
+        "name": "scotte-snyk/test-project-2:package.json",
+        "repo_full_name": "scotte-snyk/test-project-2",
+        "repo_owner": "scotte-snyk",
+        "repo_name": "test-project-2",
+        "manifest": "package.json",
+        "org_id": "12345",
+        "org_name": "scotte-snyk",
+        "origin": "github",
+        "type": "npm",
+        "integration_id": "66d7ebef-9b36-464f-889c-b92c9ef5ce12",
+        "branch_from_name": "",
+        "branch": "master"
+    },
+    ]
+
+    snyk_repos_from_snyk_projects = [
+        SnykRepo(
+            'scotte-snyk/test-project-1',
+            "12345",
+            "scotte-snyk",
+            "66d7ebef-9b36-464f-889c-b92c9ef5ce12",
+            "github",
+            "master",
+            [snyk_gh_projects[0]]
+        ),
+        SnykRepo(
+            'scotte-snyk/test-project-2',
+            "12345",
+            "scotte-snyk",
+            "66d7ebef-9b36-464f-889c-b92c9ef5ce12",
+            "github",
+            "master",
+            [snyk_gh_projects[1]]
+        )
+    ]
+
+    assert str(get_snyk_repos_from_snyk_projects(snyk_gh_projects)) == str(snyk_repos_from_snyk_projects)
 
 def test_get_snyk_project_for_repo():
     """ test collecting projects for a repo """

--- a/app/utils/snyk_helper.py
+++ b/app/utils/snyk_helper.py
@@ -37,63 +37,43 @@ def get_snyk_repos_from_snyk_orgs(snyk_orgs, ARGS):
     snyk_repos = []
     snyk_projects = build_snyk_project_list(snyk_orgs, ARGS)
 
-    repo_projects = []
-
     # initialize to the first repo name
     num_projects = len(snyk_projects)
 
     if num_projects > 0:
-        curr_repo_name = snyk_projects[0]["repo_full_name"]
-        # print(f"curr repo name: {curr_repo_name}")
+        snyk_repos = get_snyk_repos_from_snyk_projects(snyk_projects)
 
-        for (i, project) in enumerate(snyk_projects):
-            #if i == num_projects-1:
-                # print(f"encountered base case")
-            #    snyk_repos.append(
-            #        SnykRepo(snyk_projects[i]["repo_full_name"],
-            #                 snyk_projects[i]["org_id"],
-            #                 snyk_projects[i]["org_name"],
-            #                 snyk_projects[i]["integration_id"],
-            #                 snyk_projects[i]["origin"],
-            #                 snyk_projects[i]["branch"],
-            #                 repo_projects)
-            #    )
+    return snyk_repos
 
-            # we encountered a new repo, or reached the end of the project list
-            if project["repo_full_name"] != curr_repo_name:
-                # print(f"encountered a new repo name: {project['repo_full_name']}")
-                # add repo to snyk_repos
-                snyk_repos.append(
-                    SnykRepo(snyk_projects[i-1]["repo_full_name"],
-                             snyk_projects[i-1]["org_id"],
-                             snyk_projects[i-1]["org_name"],
-                             snyk_projects[i-1]["integration_id"],
-                             snyk_projects[i-1]["origin"],
-                             snyk_projects[i-1]["branch"],
-                             repo_projects)
-                )
-                repo_projects = [project]
-                # print(f"setting repo_projects to: {repo_projects}")
+def get_snyk_repos_from_snyk_projects(snyk_projects):
+    """ Get list of unique repos built from an input of snyk projects"""
+    snyk_repos = []
+    # num_projects = len(snyk_projects)
+    curr_repo_name = ""
 
-                if i == num_projects-1:
-                    # print("encountered last project")
-                    snyk_repos.append(
-                        SnykRepo(snyk_projects[i]["repo_full_name"],
-                                 snyk_projects[i]["org_id"],
-                                 snyk_projects[i]["org_name"],
-                                 snyk_projects[i]["integration_id"],
-                                 snyk_projects[i]["origin"],
-                                 snyk_projects[i]["branch"],
-                                 repo_projects)
-                    )
+    repo_projects = []
+    for (i, project) in enumerate(snyk_projects):
 
-            else:
-                # add to project list for this repo
-                repo_projects.append(project)
-                # print(f"adding project: {project['manifest']}")
+        # we encountered a new repo
+        if project["repo_full_name"] != curr_repo_name:
+            # add repo to snyk_repos
+            snyk_repos.append(
+                SnykRepo(snyk_projects[i]["repo_full_name"],
+                         snyk_projects[i]["org_id"],
+                         snyk_projects[i]["org_name"],
+                         snyk_projects[i]["integration_id"],
+                         snyk_projects[i]["origin"],
+                         snyk_projects[i]["branch"],
+                         [x for x in snyk_projects \
+                             if x["repo_full_name"] == project["repo_full_name"]])
+            )
+            repo_projects = []
 
-            curr_repo_name = project["repo_full_name"]
-            # print(f"curr repo name set to: {curr_repo_name}")
+        else:
+            repo_projects.append(project)
+
+        curr_repo_name = project["repo_full_name"]
+
     return snyk_repos
 
 def build_snyk_project_list(snyk_orgs, ARGS):


### PR DESCRIPTION
n-1 repos are processed due to bug.  so if you 5 repositories you have previously imported to snyk, this tool is detecting and processing refresh for only 4. similarly if only 1, then it will process 0 and exit.

this was due to an if statement that should not have been nested.