### PR TITLE
feat/audit large repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ optional arguments:
   --dry-run             Simulate processing of the script without making changes to Snyk
   --skip-scm-validation
                         Skip validation of the TLS certificate used by the SCM
+  --audit-large-repos   only query github tree api to see if the response is truncated and 
+                        log the result. These are the repos that would have be cloned via this tool
   --debug               Write detailed debug data to snyk_scm_refresh.log for troubleshooting
 ```
 
@@ -136,3 +138,10 @@ Large repo detected, falling back to cloning. This may take a few minutes ...
 ![image](https://user-images.githubusercontent.com/59706011/163878251-e874b073-eab6-48c0-9bd3-ea995005e4a9.png)
 
 The truncated GIT tree response is described [here](https://docs.github.com/en/rest/reference/git#get-a-tree).  The last [known limits](https://github.community/t/github-get-tree-api-limits-and-recursivity/1300/2) are: 100,000 files or 7 MB of response data, whichever is first.
+
+### Auditing which repos are considered large
+In order to detect which repositories in snyk are subject the tree truncation issue mentioned above, there is another available option `--audit-large-repos`.
+This will only query the git tree via API and look for a truncated response, and then log the results to a file `snyk-scm-refresh_large-repos-audit-results.csv`
+
+To find all the repos based on a Snyk org, use the `--org-id` parameter in conjunction with `--audit-large-repos`
+Optionally you can also supply a repo name to check a single repo by also supplying the `--repo-name` filter.

--- a/app/utils/github_utils.py
+++ b/app/utils/github_utils.py
@@ -3,6 +3,7 @@ methods for creating github or
 github enterprise clients
 """
 from github import Github
+import common
 
 # pylint: disable=invalid-name
 def create_github_client(GITHUB_TOKEN, VERIFY_TLS):
@@ -23,3 +24,22 @@ def create_github_enterprise_client(GITHUB_ENTERPRISE_TOKEN, GITHUB_ENTERPRISE_H
         raise RuntimeError(
             "Failed to initialize GitHub client because GITHUB_ENTERPRISE_TOKEN is not set!"
         ) from err
+
+def get_github_client(origin):
+    """ get the right github client depending on intergration type """
+    #pylint: disable=no-else-return
+    if origin == 'github':
+        return common.gh_client
+    elif origin == 'github-enterprise':
+        return common.gh_enterprise_client
+    else:
+        raise Exception(f"could not get github client for type: {origin}")
+
+def get_github_repo(gh_client, repo_name):
+    """ get a github repo by name """
+    try:
+        return gh_client.get_repo(repo_name)
+    # pylint: disable=bare-except
+    except:
+        return gh_client.get_user().get_repo(repo_name)
+ 

--- a/app/utils/snyk_helper.py
+++ b/app/utils/snyk_helper.py
@@ -32,6 +32,13 @@ def log_update_project_branch_error(org_name, project_id, project_name, new_bran
         f"{project_id},"
         f"{new_branch}\n")
 
+def log_audit_large_repo_result(org_name: str, repo_name: str, is_large: str):
+    """ Log audit large repo result """
+    common.LARGE_REPOS_AUDIT_RESULTS_FILE.write(
+        f"{org_name},"
+        f"{repo_name},"
+        f"{is_large}\n")
+
 def get_snyk_repos_from_snyk_orgs(snyk_orgs, ARGS):
     """Build list of repositories from a given list of Snyk orgs"""
     snyk_repos = []

--- a/common.py
+++ b/common.py
@@ -61,6 +61,10 @@ UPDATE_PROJECT_BRANCHES_ERRORS_FILE = open(
     "%s_update-project-branches-errors.csv" % LOG_PREFIX, "w"
 )
 UPDATE_PROJECT_BRANCHES_ERRORS_FILE.write("org,project_name,project_id,new_branch\n")
+LARGE_REPOS_AUDIT_RESULTS_FILE = open(
+    "%s_large-repos-audit-results.csv" % LOG_PREFIX, "w"
+)
+LARGE_REPOS_AUDIT_RESULTS_FILE.write("org,repo,is_large\n")
 
 PENDING_REMOVAL_MAX_CHECKS = 45
 PENDING_REMOVAL_CHECK_INTERVAL = 20
@@ -120,6 +124,13 @@ def parse_command_line_args():
     parser.add_argument(
         "--skip-scm-validation",
         help="Skip validation of the TLS certificate used by the SCM",
+        required=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--audit-large-repos",
+        help="only query github tree api to see if the response is truncated and \
+            log the result. These are the repos that would have be cloned via this tool",
         required=False,
         action="store_true",
     )

--- a/snyk_scm_refresh.py
+++ b/snyk_scm_refresh.py
@@ -10,7 +10,10 @@ from app import run
 
 if __name__ == "__main__":
 
-    if common.ARGS.dry_run:
+    if common.ARGS.audit_large_repos:
+        print("\n****** AUDIT LARGE REPOS MODE ******\n")
+        print(f"check {common.LARGE_REPOS_AUDIT_RESULTS_FILE.name} after script completes\n")
+    elif common.ARGS.dry_run:
         print("\n****** DRY-RUN MODE ******\n")
     for arg in vars(common.ARGS):
         if any(arg in x for x in ['sca', 'container', 'iac', 'code']):


### PR DESCRIPTION
enable feature to audit large repos, to detect whether the API git tree response from github is truncated or not.  This indicates that a given repo will need to be cloned locally in order to detect its files and determine which projects need to be refreshed into Snyk.

can test against a single repo with:

`./snyk_scm_refresh.py --org-id=<org_id> --audit-large-repos --repo-name=<owner/repo_name>`

the [kibana](https://github.com/elastic/kibana) repo is large enough test on if you clone it and import into snyk

after running, the results of all repos processed are written to `snyk-scm-refresh_large-repos-audit-results.csv`

![image](https://user-images.githubusercontent.com/59706011/165849978-40689fd4-b16e-4a66-b989-b5c0c710e065.png)

